### PR TITLE
Remove contextual data style options

### DIFF
--- a/src/blocks/line/components/data-styles.js
+++ b/src/blocks/line/components/data-styles.js
@@ -70,37 +70,30 @@ export default class DataStyles extends Component {
 							</FlexBlock>
 						</Flex>
 					</CardHeader>
-					{ ( parsedData.datasets[ this.state.activeDataset ].pointRadius > 0 ||
-						parsedData.datasets[ this.state.activeDataset ].showLine ) && (
-						<CardBody>
-							{ parsedData.datasets[ this.state.activeDataset ].pointRadius > 0 && (
-								<SelectControl
-									label="Point Style"
-									value={ parsedData.datasets[ this.state.activeDataset ].pointStyle }
-									options={ [
-										{ label: 'Circle', value: 'circle' },
-										{ label: 'Rectangle', value: 'rect' },
-										{ label: 'Rounded Rectangle', value: 'rectRounded' },
-										{ label: 'Diamond', value: 'rectRot' },
-										{ label: 'Triangle', value: 'triangle' },
-									] }
-									onChange={ ( style ) => updateDatasetPointStyle( style, this.state.activeDataset ) }
-								/>
-							) }
-							{ parsedData.datasets[ this.state.activeDataset ].showLine && (
-								<BaseControl
-									label="Color"
-									id={ `inspect-chart-line-border-color-${ clientId }` }
-								>
-									<ColorPalette
-										value={ parsedData.datasets[ this.state.activeDataset ].borderColor }
-										clearable={ false }
-										onChange={ ( color ) => updateDatasetColor( color, this.state.activeDataset ) }
-									/>
-								</BaseControl>
-							) }
-						</CardBody>
-					) }
+					<CardBody>
+						<SelectControl
+							label="Point Style"
+							value={ parsedData.datasets[ this.state.activeDataset ].pointStyle }
+							options={ [
+								{ label: 'Circle', value: 'circle' },
+								{ label: 'Rectangle', value: 'rect' },
+								{ label: 'Rounded Rectangle', value: 'rectRounded' },
+								{ label: 'Diamond', value: 'rectRot' },
+								{ label: 'Triangle', value: 'triangle' },
+							] }
+							onChange={ ( style ) => updateDatasetPointStyle( style, this.state.activeDataset ) }
+						/>
+						<BaseControl
+							label="Color"
+							id={ `inspect-chart-line-border-color-${ clientId }` }
+						>
+							<ColorPalette
+								value={ parsedData.datasets[ this.state.activeDataset ].borderColor }
+								clearable={ false }
+								onChange={ ( color ) => updateDatasetColor( color, this.state.activeDataset ) }
+							/>
+						</BaseControl>
+					</CardBody>
 				</Card>
 				<Flex>
 					<FlexItem>

--- a/src/blocks/pie/components/data-styles.js
+++ b/src/blocks/pie/components/data-styles.js
@@ -76,23 +76,19 @@ export default class DataStyles extends Component {
 						</Flex>
 					</CardHeader>
 					<CardBody>
-						{ parsedData.datasets[ this.state.activeDataset ].borderColor && (
-							<>
-								{ parsedData.labels.map( ( label, row ) => (
-									<BaseControl
-										key={ row }
-										label={ label + ' Color' }
-										id={ `inspect-chart-pie-border-color-${ clientId }-${ row }` }
-									>
-										<ColorPalette
-											value={ getColor( this.state.activeDataset, row ) }
-											clearable={ false }
-											onChange={ ( color ) => updateSegmentColor( color, this.state.activeDataset, row ) }
-										/>
-									</BaseControl>
-								) ) }
-							</>
-						) }
+						{ parsedData.labels.map( ( label, row ) => (
+							<BaseControl
+								key={ row }
+								label={ label + ' Color' }
+								id={ `inspect-chart-pie-border-color-${ clientId }-${ row }` }
+							>
+								<ColorPalette
+									value={ getColor( this.state.activeDataset, row ) }
+									clearable={ false }
+									onChange={ ( color ) => updateSegmentColor( color, this.state.activeDataset, row ) }
+								/>
+							</BaseControl>
+						) ) }
 					</CardBody>
 				</Card>
 				<Flex>

--- a/src/blocks/radar/components/data-styles.js
+++ b/src/blocks/radar/components/data-styles.js
@@ -71,20 +71,18 @@ export default class DataStyles extends Component {
 						</Flex>
 					</CardHeader>
 					<CardBody>
-						{ parsedData.datasets[ this.state.activeDataset ].pointRadius > 0 && (
-							<SelectControl
-								label="Point Style"
-								value={ parsedData.datasets[ this.state.activeDataset ].pointStyle }
-								options={ [
-									{ label: 'Circle', value: 'circle' },
-									{ label: 'Rectangle', value: 'rect' },
-									{ label: 'Rounded Rectangle', value: 'rectRounded' },
-									{ label: 'Diamond', value: 'rectRot' },
-									{ label: 'Triangle', value: 'triangle' },
-								] }
-								onChange={ ( style ) => updateDatasetPointStyle( style, this.state.activeDataset ) }
-							/>
-						) }
+						<SelectControl
+							label="Point Style"
+							value={ parsedData.datasets[ this.state.activeDataset ].pointStyle }
+							options={ [
+								{ label: 'Circle', value: 'circle' },
+								{ label: 'Rectangle', value: 'rect' },
+								{ label: 'Rounded Rectangle', value: 'rectRounded' },
+								{ label: 'Diamond', value: 'rectRot' },
+								{ label: 'Triangle', value: 'triangle' },
+							] }
+							onChange={ ( style ) => updateDatasetPointStyle( style, this.state.activeDataset ) }
+						/>
 						<BaseControl
 							label="Color"
 							id={ `inspect-chart-line-border-color-${ clientId }` }


### PR DESCRIPTION
Fixes #51.

I originally intended for the data styles to be reflective of the chart settings. For example, why show point style, if your point width is set to 0? 

But on reflection, that kind of unnecessarily complicates things. Better if we just always show all the data styles, all the time.