### PR TITLE
Remove workaround for a Gutenberg bug that's now fixed

### DIFF
--- a/src/common/helpers/random-colors.js
+++ b/src/common/helpers/random-colors.js
@@ -1,5 +1,3 @@
-/* global helloCharts */
-
 /**
  * Chooses a random theme colors.
  *
@@ -17,17 +15,8 @@ const randomColors = ( length ) => {
 		'white',
 	];
 
-	// Retrieve the default WordPress colors.
-	let colorsObject = wp.data.select( 'core/block-editor' ).getSettings().colors;
-
-	// Use the theme colours instead, if they're defined.
-	if (
-		'undefined' !== typeof helloCharts &&
-		helloCharts.hasOwnProperty( 'themeColors' ) &&
-		helloCharts.themeColors[ 0 ].length > 0
-	) {
-		colorsObject = helloCharts.themeColors[ 0 ];
-	}
+	// Retrieve the active color scheme.
+	const colorsObject = wp.data.select( 'core/block-editor' ).getSettings().colors;
 
 	// Remove boring colors, like black & white.
 	const filteredColors = colorsObject.filter(

--- a/src/init.php
+++ b/src/init.php
@@ -91,12 +91,6 @@ function hello_charts_block_assets() {
 		true
 	);
 
-	wp_localize_script(
-		'hello-charts-block-js',
-		'helloCharts',
-		[ 'themeColors' => get_theme_support( 'editor-color-palette' ) ]
-	);
-
 	$block_type_args = [
 		'style'         => 'hello-charts-style-css',
 		'script'        => 'chart-js',


### PR DESCRIPTION
Fixes #59.

**Note**: Using the very latest version of Gutenberg right now has a slightly different bug, where you'll get BOTH the default WordPress colors as well as the theme's colors. However, I think it's okay to merge this, as that bug has a fix already, and is on the "WordPress 5.8 Must Haves" list.

https://github.com/WordPress/gutenberg/issues/32027