### PR TITLE
Fix small display issue in modal

### DIFF
--- a/src/editor.scss
+++ b/src/editor.scss
@@ -35,6 +35,10 @@
 		}
     }
 
+	.components-modal__content:before {
+		margin-bottom: 0;
+	}
+
     table {
         position: relative;
         border-collapse: collapse;


### PR DESCRIPTION
There's a bit of extra margin added to the modal in the latest version of the Gutenberg plugin. This fixes that.

Resolves #82.