### PR TITLE
Add chart size control by changing chart width

### DIFF
--- a/js/blocks/bar/components/chart-styles.js
+++ b/js/blocks/bar/components/chart-styles.js
@@ -7,12 +7,13 @@ const {
 	PanelBody,
 	SelectControl,
 	ToggleControl,
+	RangeControl,
 } = wp.components;
 
 export default class ChartStyles extends Component {
 	render() {
 		const {
-			attributes: { chartOptions },
+			attributes: { chartOptions, chartSize },
 			setAttributes,
 		} = this.props;
 
@@ -45,6 +46,10 @@ export default class ChartStyles extends Component {
 			setAttributes( { chartOptions: JSON.stringify( options ) } );
 		}
 
+		function updateChartSize( width ) {
+			setAttributes( { chartSize: width } );
+		}
+
 		return (
 			<PanelBody title={ __( 'Chart Styles', 'hello-charts' ) } initialOpen={ true }>
 				<SelectControl
@@ -74,6 +79,15 @@ export default class ChartStyles extends Component {
 						parsedOptions.scales.y.grid.display
 					}
 					onChange={ ( state ) => updateShowGridLines( state, 'y' ) }
+				/>
+				<RangeControl
+					label={ __( 'Chart Size', 'hello-charts' ) }
+					value={ chartSize }
+					onChange={ ( width ) => updateChartSize( width ) }
+					min={ 1 }
+					max={ window.outerWidth }
+					allowReset
+					withInputField={ false }
 				/>
 			</PanelBody>
 		);

--- a/js/blocks/bar/index.js
+++ b/js/blocks/bar/index.js
@@ -42,6 +42,9 @@ const attributes = {
 	width: {
 		type: 'number',
 	},
+	chartSize: {
+		type: 'number',
+	},
 	chartType: {
 		type: 'string',
 	},
@@ -63,6 +66,7 @@ const attributes = {
 		default: JSON.stringify( {
 			init: false,
 			animation: false,
+			responsive: true,
 			indexAxis: 'x',
 			plugins: {
 				legend: {
@@ -134,7 +138,7 @@ registerBlockType( 'hello-charts/block-bar', {
 			} ),
 			chartOptions: JSON.stringify( {
 				animation: false,
-				responsive: false,
+				responsive: true,
 				plugins: {
 					legend: {
 						display: false,
@@ -165,6 +169,7 @@ registerBlockType( 'hello-charts/block-bar', {
 					to.title = from.title;
 					to.showChartTitle = from.showChartTitle;
 					to.showChartBackground = from.showChartBackground;
+					to.chartSize = from.chartSize;
 
 					/*
 					 * We're intentionally setting the x stacked attribute to the same as y,

--- a/js/blocks/line/components/chart-styles.js
+++ b/js/blocks/line/components/chart-styles.js
@@ -12,7 +12,7 @@ const {
 export default class ChartStyles extends Component {
 	render() {
 		const {
-			attributes: { chartData, chartOptions },
+			attributes: { chartData, chartOptions, chartSize },
 			setAttributes,
 		} = this.props;
 
@@ -63,6 +63,10 @@ export default class ChartStyles extends Component {
 			setAttributes( { chartData: JSON.stringify( data ) } );
 		}
 
+		function updateChartSize( width ) {
+			setAttributes( { chartSize: width } );
+		}
+
 		return (
 			<PanelBody title={ __( 'Chart Styles', 'hello-charts' ) } initialOpen={ true }>
 				<ToggleControl
@@ -90,6 +94,15 @@ export default class ChartStyles extends Component {
 					onChange={ ( tension ) => updateLineTension( tension / 20 ) }
 					min={ 0 }
 					max={ 10 }
+				/>
+				<RangeControl
+					label={ __( 'Chart Size', 'hello-charts' ) }
+					value={ chartSize }
+					onChange={ ( width ) => updateChartSize( width ) }
+					min={ 1 }
+					max={ window.outerWidth }
+					allowReset
+					withInputField={ false }
 				/>
 			</PanelBody>
 		);

--- a/js/blocks/line/index.js
+++ b/js/blocks/line/index.js
@@ -42,6 +42,9 @@ const attributes = {
 	width: {
 		type: 'number',
 	},
+	chartSize: {
+		type: 'number',
+	},
 	chartType: {
 		type: 'string',
 	},
@@ -81,6 +84,7 @@ const attributes = {
 		default: JSON.stringify( {
 			init: false,
 			animation: false,
+			responsive: true,
 			plugins: {
 				legend: {
 					display: true,
@@ -172,7 +176,7 @@ registerBlockType( 'hello-charts/block-line', {
 			} ),
 			chartOptions: JSON.stringify( {
 				animation: false,
-				responsive: false,
+				responsive: true,
 				plugins: {
 					legend: {
 						display: false,
@@ -204,6 +208,7 @@ registerBlockType( 'hello-charts/block-line', {
 					to.title = from.title;
 					to.showChartTitle = from.showChartTitle;
 					to.showChartBackground = from.showChartBackground;
+					to.chartSize = from.chartSize;
 
 					toOptions.plugins.legend = fromOptions.plugins.legend;
 					toOptions.scales.y.stacked = fromOptions.scales?.y?.stacked ?? false;

--- a/js/blocks/pie/components/chart-styles.js
+++ b/js/blocks/pie/components/chart-styles.js
@@ -11,7 +11,7 @@ const {
 export default class ChartStyles extends Component {
 	render() {
 		const {
-			attributes: { chartData },
+			attributes: { chartData, chartSize },
 			setAttributes,
 		} = this.props;
 
@@ -25,6 +25,10 @@ export default class ChartStyles extends Component {
 			setAttributes( { chartData: JSON.stringify( data ) } );
 		}
 
+		function updateChartSize( width ) {
+			setAttributes( { chartSize: width } );
+		}
+
 		return (
 			<PanelBody title={ __( 'Chart Styles', 'hello-charts' ) } initialOpen={ true }>
 				<RangeControl
@@ -34,6 +38,15 @@ export default class ChartStyles extends Component {
 					min={ 0 }
 					max={ 90 }
 					step={ 10 }
+				/>
+				<RangeControl
+					label={ __( 'Chart Size', 'hello-charts' ) }
+					value={ chartSize }
+					onChange={ ( width ) => updateChartSize( width ) }
+					min={ 1 }
+					max={ window.outerWidth }
+					allowReset
+					withInputField={ false }
 				/>
 			</PanelBody>
 		);

--- a/js/blocks/pie/index.js
+++ b/js/blocks/pie/index.js
@@ -47,6 +47,9 @@ const attributes = {
 	width: {
 		type: 'number',
 	},
+	chartSize: {
+		type: 'number',
+	},
 	chartType: {
 		type: 'string',
 	},
@@ -69,6 +72,7 @@ const attributes = {
 		default: JSON.stringify( {
 			init: false,
 			animation: false,
+			responsive: true,
 			plugins: {
 				legend: {
 					display: true,
@@ -127,7 +131,7 @@ registerBlockType( 'hello-charts/block-pie', {
 			} ),
 			chartOptions: JSON.stringify( {
 				animation: false,
-				responsive: false,
+				responsive: true,
 				layout: {
 					padding: 0,
 				},
@@ -161,6 +165,7 @@ registerBlockType( 'hello-charts/block-pie', {
 					to.title = from.title;
 					to.showChartTitle = from.showChartTitle;
 					to.showChartBackground = from.showChartBackground;
+					to.chartSize = from.chartSize;
 
 					toOptions.plugins.legend = fromOptions.plugins.legend;
 					to.chartOptions = JSON.stringify( toOptions );

--- a/js/blocks/polar-area/components/chart-styles.js
+++ b/js/blocks/polar-area/components/chart-styles.js
@@ -6,12 +6,13 @@ const { Component } = wp.element;
 const {
 	PanelBody,
 	ToggleControl,
+	RangeControl,
 } = wp.components;
 
 export default class ChartStyles extends Component {
 	render() {
 		const {
-			attributes: { chartOptions },
+			attributes: { chartOptions, chartSize },
 			setAttributes,
 		} = this.props;
 
@@ -29,6 +30,10 @@ export default class ChartStyles extends Component {
 			setAttributes( { chartOptions: JSON.stringify( options ) } );
 		}
 
+		function updateChartSize( width ) {
+			setAttributes( { chartSize: width } );
+		}
+
 		return (
 			<PanelBody title={ __( 'Chart Styles', 'hello-charts' ) } initialOpen={ true }>
 				<ToggleControl
@@ -44,6 +49,15 @@ export default class ChartStyles extends Component {
 						parsedOptions.scales.r.ticks.display
 					}
 					onChange={ ( state ) => updateShowTicks( state ) }
+				/>
+				<RangeControl
+					label={ __( 'Chart Size', 'hello-charts' ) }
+					value={ chartSize }
+					onChange={ ( width ) => updateChartSize( width ) }
+					min={ 1 }
+					max={ window.outerWidth }
+					allowReset
+					withInputField={ false }
 				/>
 			</PanelBody>
 		);

--- a/js/blocks/polar-area/index.js
+++ b/js/blocks/polar-area/index.js
@@ -47,6 +47,9 @@ const attributes = {
 	width: {
 		type: 'number',
 	},
+	chartSize: {
+		type: 'number',
+	},
 	chartType: {
 		type: 'string',
 	},
@@ -68,6 +71,7 @@ const attributes = {
 		default: JSON.stringify( {
 			init: false,
 			animation: false,
+			responsive: true,
 			plugins: {
 				legend: {
 					display: true,
@@ -138,7 +142,7 @@ registerBlockType( 'hello-charts/block-polar-area', {
 			} ),
 			chartOptions: JSON.stringify( {
 				animation: false,
-				responsive: false,
+				responsive: true,
 				plugins: {
 					legend: {
 						display: false,
@@ -179,6 +183,7 @@ registerBlockType( 'hello-charts/block-polar-area', {
 					to.title = from.title;
 					to.showChartTitle = from.showChartTitle;
 					to.showChartBackground = from.showChartBackground;
+					to.chartSize = from.chartSize;
 
 					toOptions.plugins.legend = fromOptions.plugins.legend;
 					toOptions.scales.r.grid.display = fromOptions.scales?.r?.grid?.display ?? true;

--- a/js/blocks/radar/components/chart-styles.js
+++ b/js/blocks/radar/components/chart-styles.js
@@ -12,7 +12,7 @@ const {
 export default class ChartStyles extends Component {
 	render() {
 		const {
-			attributes: { chartData, chartOptions },
+			attributes: { chartData, chartOptions, chartSize },
 			setAttributes,
 		} = this.props;
 
@@ -55,6 +55,10 @@ export default class ChartStyles extends Component {
 				data.datasets[ index ].tension = tension;
 			} );
 			setAttributes( { chartData: JSON.stringify( data ) } );
+		}
+
+		function updateChartSize( width ) {
+			setAttributes( { chartSize: width } );
 		}
 
 		return (
@@ -100,6 +104,15 @@ export default class ChartStyles extends Component {
 					onChange={ ( tension ) => updateTension( tension / 20 ) }
 					min={ 0 }
 					max={ 10 }
+				/>
+				<RangeControl
+					label={ __( 'Chart Size', 'hello-charts' ) }
+					value={ chartSize }
+					onChange={ ( width ) => updateChartSize( width ) }
+					min={ 1 }
+					max={ window.outerWidth }
+					allowReset
+					withInputField={ false }
 				/>
 			</PanelBody>
 		);

--- a/js/blocks/radar/index.js
+++ b/js/blocks/radar/index.js
@@ -42,6 +42,9 @@ const attributes = {
 	width: {
 		type: 'number',
 	},
+	chartSize: {
+		type: 'number',
+	},
 	chartType: {
 		type: 'string',
 	},
@@ -70,6 +73,7 @@ const attributes = {
 		default: JSON.stringify( {
 			init: false,
 			animation: false,
+			responsive: true,
 			plugins: {
 				legend: {
 					display: false,
@@ -148,7 +152,7 @@ registerBlockType( 'hello-charts/block-radar', {
 			} ),
 			chartOptions: JSON.stringify( {
 				animation: false,
-				responsive: false,
+				responsive: true,
 				plugins: {
 					legend: {
 						display: false,
@@ -191,6 +195,7 @@ registerBlockType( 'hello-charts/block-radar', {
 					to.title = from.title;
 					to.showChartTitle = from.showChartTitle;
 					to.showChartBackground = from.showChartBackground;
+					to.chartSize = from.chartSize;
 
 					toOptions.plugins.legend = fromOptions.plugins.legend;
 					toOptions.scales.r.grid.display = fromOptions.scales?.r?.grid?.display ?? true;

--- a/js/common/components/chart-block.js
+++ b/js/common/components/chart-block.js
@@ -159,6 +159,7 @@ export default class ChartBlock extends Component {
 			attributes: {
 				showChartTitle,
 				showChartBackground,
+				chartSize,
 				title,
 			},
 			children,
@@ -167,6 +168,11 @@ export default class ChartBlock extends Component {
 			hasSegments,
 			titlePlaceholder,
 		} = this.props;
+
+		const styles = {
+			width: chartSize ? chartSize : '',
+			margin: chartSize ? 'auto' : '',
+		};
 
 		this.toggleEditor = this.toggleEditor.bind( this );
 
@@ -187,7 +193,7 @@ export default class ChartBlock extends Component {
 					<ChartFormattingToolbar { ...this.props } />
 				</BlockControls>
 				<div className={ className } key="preview">
-					<div className={ showChartBackground ? 'wrapper has-chart-background' : 'wrapper' }>
+					<div className={ showChartBackground ? 'wrapper has-chart-background' : 'wrapper' } style={ styles }>
 						{ showChartTitle && (
 							<RichText
 								tagName="h3"

--- a/js/common/components/save.js
+++ b/js/common/components/save.js
@@ -8,13 +8,19 @@ export default class Save extends Component {
 	render() {
 		// Setup the attributes
 		const {
-			attributes: { title, blockId, showChartBackground },
+			attributes: { title, blockId, showChartBackground, chartSize },
 			className,
 		} = this.props;
 
+		const styles = {
+			width: chartSize ? chartSize : '',
+			maxWidth: chartSize ? '100%' : '',
+			margin: chartSize ? 'auto' : '',
+		};
+
 		return (
 			<div className={ className }>
-				<div className={ showChartBackground ? 'wrapper has-chart-background' : 'wrapper' }>
+				<div className={ showChartBackground ? 'wrapper has-chart-background' : 'wrapper' } style={ styles }>
 					<RichText.Content tagName="h3" className="chart-title" value={ title } />
 					<canvas id={ `chart-${ blockId }` }></canvas>
 				</div>


### PR DESCRIPTION
Resolves #22.

Added a chart resizer in Chart Styles using a RangeControl component.

This took a lot of experimenting on what was the best method for adjusting the height while keeping the block responsive and in proportion.

Adding the 'responsive attribute from ChartJS allowed for adjusting the width while maintaining proportions and alignment.

I experimented using the 'center' block alignment support but I wasn't happy with how the block was resizing with this enabled, so I opted to exclude this and setting margin: auto instead in order to look better on the page.

I wanted to set the innitial starting point of the slider as the current width of block when the block is first added. I tried this by passing the 'chartRef' as a prop to the chart styles component and using .current.offsetWidth to get the current width as a starting point. This worked fine at the start but if I changed the block alignment to full or wide, it broke the block as it lost access to the variable. I don't know a smart solution yet to overcome that.

I opted again to use inline styles to adjust the width as I am not sure of how else to update these dynamically using css. I looked the core image block to perhaps use the 25% 50% 100% method with classes but I noticed that these percentages were based on the original size of the image and didn't translate well to the block which is given a dynamically generated width based on the container.

I chose to add a max width property on the frontend so no matter how big you made the block, it would always stay within its container. I debated adding this to the backend styles but noticed the image block didn't have it and decided against it. We can still add this in the backend or even remove it on the frontend if you want the chart to expand over the container.