### PR TITLE
Rename chart background variable

### DIFF
--- a/js/blocks/bar/index.js
+++ b/js/blocks/bar/index.js
@@ -28,7 +28,7 @@ const attributes = {
 		type: 'boolean',
 		default: true,
 	},
-	chartBackground: {
+	backgroundColor: {
 		type: 'string',
 		default: '',
 	},
@@ -118,7 +118,7 @@ registerBlockType( 'hello-charts/block-bar', {
 		attributes: {
 			title: __( 'Bar Chart', 'hello-charts' ),
 			showChartTitle: false,
-			chartBackground: '',
+			backgroundColor: '',
 			height: 280,
 			width: 450,
 			chartData: JSON.stringify( {
@@ -165,7 +165,7 @@ registerBlockType( 'hello-charts/block-bar', {
 
 					to.title = from.title;
 					to.showChartTitle = from.showChartTitle;
-					to.chartBackground = from.chartBackground;
+					to.backgroundColor = from.backgroundColor;
 
 					/*
 					 * We're intentionally setting the x stacked attribute to the same as y,

--- a/js/blocks/line/index.js
+++ b/js/blocks/line/index.js
@@ -28,7 +28,7 @@ const attributes = {
 		type: 'boolean',
 		default: true,
 	},
-	chartBackground: {
+	backgroundColor: {
 		type: 'string',
 		default: '',
 	},
@@ -135,7 +135,7 @@ registerBlockType( 'hello-charts/block-line', {
 		attributes: {
 			title: __( 'Line Chart', 'hello-charts' ),
 			showChartTitle: false,
-			chartBackground: '',
+			backgroundColor: '',
 			height: 280,
 			width: 450,
 			chartData: JSON.stringify( {
@@ -204,7 +204,7 @@ registerBlockType( 'hello-charts/block-line', {
 
 					to.title = from.title;
 					to.showChartTitle = from.showChartTitle;
-					to.chartBackground = from.chartBackground;
+					to.backgroundColor = from.backgroundColor;
 
 					toOptions.plugins.legend = fromOptions.plugins.legend;
 					toOptions.scales.y.stacked = fromOptions.scales?.y?.stacked ?? false;

--- a/js/blocks/pie/index.js
+++ b/js/blocks/pie/index.js
@@ -33,7 +33,7 @@ const attributes = {
 		type: 'boolean',
 		default: true,
 	},
-	chartBackground: {
+	backgroundColor: {
 		type: 'string',
 		default: '',
 	},
@@ -109,7 +109,7 @@ registerBlockType( 'hello-charts/block-pie', {
 		attributes: {
 			title: __( 'Pie Chart', 'hello-charts' ),
 			showChartTitle: false,
-			chartBackground: '',
+			backgroundColor: '',
 			height: 280,
 			chartData: JSON.stringify( {
 				datasets: [
@@ -161,7 +161,7 @@ registerBlockType( 'hello-charts/block-pie', {
 
 					to.title = from.title;
 					to.showChartTitle = from.showChartTitle;
-					to.chartBackground = from.chartBackground;
+					to.backgroundColor = from.backgroundColor;
 
 					toOptions.plugins.legend = fromOptions.plugins.legend;
 

--- a/js/blocks/polar-area/index.js
+++ b/js/blocks/polar-area/index.js
@@ -33,7 +33,7 @@ const attributes = {
 		type: 'boolean',
 		default: true,
 	},
-	chartBackground: {
+	backgroundColor: {
 		type: 'string',
 		default: '',
 	},
@@ -118,7 +118,7 @@ registerBlockType( 'hello-charts/block-polar-area', {
 		attributes: {
 			title: __( 'Polar Area Chart', 'hello-charts' ),
 			showChartTitle: false,
-			chartBackground: '',
+			backgroundColor: '',
 			height: 280,
 			chartData: JSON.stringify( {
 				labels: [ 'A', 'B', 'C', 'D', 'E', 'F' ],
@@ -179,7 +179,7 @@ registerBlockType( 'hello-charts/block-polar-area', {
 
 					to.title = from.title;
 					to.showChartTitle = from.showChartTitle;
-					to.chartBackground = from.chartBackground;
+					to.backgroundColor = from.backgroundColor;
 
 					toOptions.plugins.legend = fromOptions.plugins.legend;
 					toOptions.scales.r.grid.display = fromOptions.scales?.r?.grid?.display ?? true;

--- a/js/blocks/radar/index.js
+++ b/js/blocks/radar/index.js
@@ -28,7 +28,7 @@ const attributes = {
 		type: 'boolean',
 		default: true,
 	},
-	chartBackground: {
+	backgroundColor: {
 		type: 'string',
 		default: '',
 	},
@@ -127,7 +127,7 @@ registerBlockType( 'hello-charts/block-radar', {
 		attributes: {
 			title: __( 'Radar Chart', 'hello-charts' ),
 			showChartTitle: false,
-			chartBackground: '',
+			backgroundColor: '',
 			height: 280,
 			chartData: JSON.stringify( {
 				labels: [ 'A', 'B', 'C', 'D', 'E', 'F' ],
@@ -191,7 +191,7 @@ registerBlockType( 'hello-charts/block-radar', {
 
 					to.title = from.title;
 					to.showChartTitle = from.showChartTitle;
-					to.chartBackground = from.chartBackground;
+					to.backgroundColor = from.backgroundColor;
 
 					toOptions.plugins.legend = fromOptions.plugins.legend;
 					toOptions.scales.r.grid.display = fromOptions.scales?.r?.grid?.display ?? true;

--- a/js/common/components/chart-block.js
+++ b/js/common/components/chart-block.js
@@ -160,8 +160,8 @@ export default class ChartBlock extends Component {
 		const {
 			AxisStyles,
 			attributes: {
+				backgroundColor,
 				showChartTitle,
-				chartBackground,
 				title,
 			},
 			children,
@@ -172,7 +172,7 @@ export default class ChartBlock extends Component {
 		} = this.props;
 
 		const styles = {
-			background: chartBackground ? chartBackground : 'none',
+			background: backgroundColor ? backgroundColor : 'none',
 		};
 
 		this.toggleEditor = this.toggleEditor.bind( this );

--- a/js/common/components/chart-styles.js
+++ b/js/common/components/chart-styles.js
@@ -17,9 +17,9 @@ export default class ChartStyles extends Component {
 	render() {
 		const {
 			attributes: {
+				backgroundColor,
 				chartData,
 				chartOptions,
-				chartBackground,
 			},
 			supports,
 			setAttributes,
@@ -105,14 +105,14 @@ export default class ChartStyles extends Component {
 						id="chart-background-color"
 						label={ __( 'Background Color', 'hello-charts' ) }
 					>
-						{ chartBackground && (
-							<ColorIndicator colorValue={ chartBackground } aria-label={ chartBackground } />
+						{ backgroundColor && (
+							<ColorIndicator colorValue={ backgroundColor } aria-label={ backgroundColor } />
 						) }
 						<ColorPalette
 							id="chart-background-color"
 							colors={ wp.data.select( 'core/block-editor' ).getSettings().colors }
-							value={ chartBackground }
-							onChange={ ( color ) => setAttributes( { chartBackground: color } ) }
+							value={ backgroundColor }
+							onChange={ ( color ) => setAttributes( { backgroundColor: color } ) }
 							clearable
 						/>
 					</BaseControl>

--- a/js/common/components/save.js
+++ b/js/common/components/save.js
@@ -8,12 +8,16 @@ export default class Save extends Component {
 	render() {
 		// Setup the attributes
 		const {
-			attributes: { title, blockId, chartBackground },
+			attributes: {
+				backgroundColor,
+				blockId,
+				title,
+			},
 			className,
 		} = this.props;
 
 		const styles = {
-			background: chartBackground ? chartBackground : 'none',
+			background: backgroundColor ? backgroundColor : 'none',
 		};
 
 		return (


### PR DESCRIPTION
This builds on the work in #114, but I wanted some feedback on this change specifically, so I thought I'd do it as a separate PR (from this branch direct into #114).

`chartBackground` isn't exactly descriptive. It could contain an image or a css property, or anything really. `backgroundColor` matches what the datasets use, and is more descriptive.