### PR TITLE
Add extra label values to line chart default data

### DIFF
--- a/js/blocks/line/components/edit.js
+++ b/js/blocks/line/components/edit.js
@@ -52,7 +52,7 @@ export default class Edit extends Component {
 					scale: 'y',
 				} }
 				generateData={ () => {
-					return randomValues( 8 );
+					return randomValues( 6 );
 				} }
 			>
 				<Line

--- a/js/blocks/line/index.js
+++ b/js/blocks/line/index.js
@@ -45,7 +45,7 @@ const attributes = {
 		type: 'string',
 		default: JSON.stringify( {
 			init: false,
-			labels: [ '1', '2', '3', '4', '5', '6', '7', '8' ],
+			labels: [ '1', '2', '3', '4', '5', '6' ],
 			datasets: [
 				{
 					label: 'A',


### PR DESCRIPTION
Resolves #113 

I found that the default data for a line chart was generating 8 values but only had 6 label values. Without us noticing, the default chart had two values that were hidden because they didn't have labels for them. When converting to other charts, they all hid the data the same except for the Radar chart which was showing the values without correct labels and caused the chart to not connect points correctly. This fix has solved all these issues.