### PR TITLE
Do not update color if color is undefined

### DIFF
--- a/js/common/components/segment-styles.js
+++ b/js/common/components/segment-styles.js
@@ -53,6 +53,10 @@ export default class SegmentStyles extends Component {
 			setAttributes,
 		} = this.props;
 
+		if ( ! color ) {
+			return;
+		}
+
 		const data = JSON.parse( chartData );
 		const segment = this.state.activeSegment;
 


### PR DESCRIPTION
Resolves #110 

The return statement I have added was the only difference between the dataset color picker code and the segment color picker code. The functionality should be identical now.