### PR TITLE
dev dep to require-dev

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,10 +5,8 @@
     "homepage": "https://github.com/Hello-Charts/Hello-Charts",
     "license": "GPL-2.0",
     "require-dev": {
+        "phpcompatibility/phpcompatibility-wp": "^2.1",
         "wp-coding-standards/wpcs": "^2.3"
-    },
-    "require": {
-        "phpcompatibility/phpcompatibility-wp": "^2.1"
     },
     "scripts": {
       "post-install-cmd": "vendor/bin/phpcs --config-set installed_paths vendor/wp-coding-standards/wpcs,vendor/phpcompatibility/phpcompatibility-wp,vendor/phpcompatibility/php-compatibility,vendor/phpcompatibility/phpcompatibility-paragonie"


### PR DESCRIPTION
Looks like the `phpcompatibility/phpcompatibility-wp` dependency not required for production/installable zip.

This moves it into `require-dev` vs `require`