### PR TITLE
Use null coalescing operator instead of OR in API response unserialization

### DIFF
--- a/php/class-license.php
+++ b/php/class-license.php
@@ -415,9 +415,9 @@ class License {
 			$response = json_decode( wp_remote_retrieve_body( $request ) );
 
 			if ( $response && $response->success ) {
-				$response->sections = maybe_unserialize( $response->sections || '' );
-				$response->banners  = maybe_unserialize( $response->banners || '' );
-				$response->icons    = maybe_unserialize( $response->icons || '' );
+				$response->sections = maybe_unserialize( $response->sections ?? '' );
+				$response->banners  = maybe_unserialize( $response->banners ?? '' );
+				$response->icons    = maybe_unserialize( $response->icons ?? '' );
 			}
 
 			return $response;


### PR DESCRIPTION
I haven't tested this, but I think it should do the trick.

Resolves #137.