### PR TITLE
Testing HTML Legend on bar chart

### DIFF
--- a/js/blocks/bar/components/edit.js
+++ b/js/blocks/bar/components/edit.js
@@ -9,6 +9,7 @@ const { createRef, Component } = wp.element;
 import { Bar } from 'react-chartjs-2';
 import { ChartBlock } from '../../../common/components';
 import { legend, randomValues } from '../../../common/helpers';
+import htmlLegendPlugin from '../../../common/helpers/html-legend-plugin';
 
 export default class Edit extends Component {
 	constructor( props ) {
@@ -60,6 +61,7 @@ export default class Edit extends Component {
 					id={ blockId }
 					data={ parsedData }
 					options={ parsedOptions }
+					plugins={ [ htmlLegendPlugin ] }
 					ref={ this.chartRef }
 				/>
 			</ChartBlock>

--- a/js/blocks/bar/index.js
+++ b/js/blocks/bar/index.js
@@ -71,6 +71,9 @@ const attributes = {
 					position: 'top',
 					align: 'center',
 				},
+				htmlLegend: {
+					containerID: 'legend-container',
+				},
 				tooltip: {
 					displayColors: false,
 				},
@@ -141,6 +144,9 @@ if ( license.isAllowedBlock( 'block-bar' ) ) {
 					animation: false,
 					responsive: false,
 					plugins: {
+						htmlLegend: {
+							containerID: 'legend-container',
+						},
 						legend: {
 							display: false,
 						},

--- a/js/common/components/chart-block.js
+++ b/js/common/components/chart-block.js
@@ -190,9 +190,12 @@ export default class ChartBlock extends Component {
 				<div className={ className } key="preview">
 					<div className="wrapper" style={ styles }>
 						{ ! this.state.editorOpen && ! this.state.refreshChart && (
-							<div className="chart" ref={ this.chartWrapperRef }>
-								{ children }
-							</div>
+							<>
+								<div id="legend-container"></div>
+								<div className="chart" ref={ this.chartWrapperRef }>
+									{ children }
+								</div>
+							</>
 						) }
 						{ this.state.editorOpen && (
 							<Modal

--- a/js/common/helpers/html-legend-plugin.js
+++ b/js/common/helpers/html-legend-plugin.js
@@ -1,0 +1,77 @@
+const getOrCreateLegendList = ( chart, id ) => {
+	const legendContainer = document.getElementById( id );
+	let listContainer = legendContainer.querySelector( 'ul' );
+
+	if ( ! listContainer ) {
+		listContainer = document.createElement( 'ul' );
+		listContainer.style.display = 'flex';
+		listContainer.style.flexDirection = 'row';
+		listContainer.style.margin = 0;
+		listContainer.style.padding = 0;
+
+		legendContainer.appendChild( listContainer );
+	}
+
+	return listContainer;
+};
+
+const htmlLegendPlugin = {
+	id: 'htmlLegend',
+	afterUpdate( chart, args, options ) {
+		const ul = getOrCreateLegendList( chart, options.containerID );
+
+		// Remove old legend items
+		while ( ul.firstChild ) {
+			ul.firstChild.remove();
+		}
+
+		// Reuse the built-in legendItems generator
+		const items = chart.options.plugins.legend.labels.generateLabels( chart );
+
+		items.forEach( ( item ) => {
+			const li = document.createElement( 'li' );
+			li.style.alignItems = 'center';
+			li.style.cursor = 'pointer';
+			li.style.display = 'flex';
+			li.style.flexDirection = 'row';
+			li.style.marginLeft = '10px';
+
+			li.onclick = () => {
+				const { type } = chart.config;
+				if ( type === 'pie' || type === 'doughnut' ) {
+				// Pie and doughnut charts only have a single dataset and visibility is per item
+					chart.toggleDataVisibility( item.index );
+				} else {
+					chart.setDatasetVisibility( item.datasetIndex, ! chart.isDatasetVisible( item.datasetIndex ) );
+				}
+				chart.update();
+			};
+
+			// Color box
+			const boxSpan = document.createElement( 'span' );
+			boxSpan.style.background = item.fillStyle;
+			boxSpan.style.borderColor = item.strokeStyle;
+			boxSpan.style.borderWidth = item.lineWidth + 'px';
+			boxSpan.style.display = 'inline-block';
+			boxSpan.style.height = '20px';
+			boxSpan.style.marginRight = '10px';
+			boxSpan.style.width = '20px';
+
+			// Text
+			const textContainer = document.createElement( 'p' );
+			textContainer.style.color = item.fontColor;
+			textContainer.style.margin = 0;
+			textContainer.style.padding = 0;
+			textContainer.style.textDecoration = item.hidden ? 'line-through' : '';
+
+			const text = document.createTextNode( item.text );
+			textContainer.appendChild( text );
+
+			li.appendChild( boxSpan );
+			li.appendChild( textContainer );
+			ul.appendChild( li );
+		} );
+	},
+};
+
+export default htmlLegendPlugin;


### PR DESCRIPTION
Resolves #94 

I have been testing this today: https://www.chartjs.org/docs/3.3.2/samples/legend/html.html

It was a bit tricky because it is way hackier than the documentation seems. I had to find a video of the developer working the whole thing out and realized he manually adds in a new div above the canvas with the id of 'legend-container'.

For a single chart on the page, it works perfectly. The code also sets up the div to be a flexbox so it is easy to move the position to the centre or end but would need a different method for moving the legend to the right, left or bottom of the chart.
![Screenshot 2022-02-01 at 19 59 29](https://user-images.githubusercontent.com/42702782/152024419-57f32d68-982d-4c6b-95ec-ffa8aaa48b62.png)

The problem is that the div should actually be dynamically generated with a unique id for each chart so the single chart can identify the only matching div and create the ul. Any idea on how to do that?

Lastly just wanted to point out that I was not able to add a 'chartPlugins' key to the attributes index.js because no matter how I went about stringifying the object, the function, afterUpdate, always disappeared and only ended up with { id: 'htmlLegend' } when the string was parsed. I couldn't get it to work at all so I just imported the object in the edit component which is not going to work out well. Any ideas on this?

