### PR TITLE
Update filter to block_caterogies_all

### DIFF
--- a/php/class-blocks.php
+++ b/php/class-blocks.php
@@ -35,7 +35,7 @@ class Blocks {
 	 * Blocks constructor.
 	 */
 	public function __construct() {
-		add_filter( 'block_categories', [ $this, 'block_categories' ] );
+		add_filter( 'block_categories_all', [ $this, 'block_categories' ] );
 		add_action( 'init', [ $this, 'block_assets' ] );
 
 		foreach ( self::BLOCK_SLUGS as $block_slug ) {


### PR DESCRIPTION
Resolves #146 

I have made this simple change to remove the deprecation warning in the console. However, this change obviously doesn't work for versions lower than 5.8.

Is this okay assuming sites should be up to date or do I need a legacy fix that will check the version and load the different filter depending on if it is higher or lower than 5.8?